### PR TITLE
Make use of cloud init for vm preparation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+kolla3/images-and-isos

--- a/kolla3/make-CONSTANTS.sh
+++ b/kolla3/make-CONSTANTS.sh
@@ -1,0 +1,7 @@
+
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+IMAGES_AND_ISOS=$SCRIPTPATH/images-and-isos
+BASE_IMAGE=$IMAGES_AND_ISOS/focal-server-cloudimg-amd64.img
+OS_VARIANT="ubuntu20.04"
+PUB_KEY=$(cat ~/.ssh/id_ed25519.pub)
+

--- a/kolla3/make-HELPER.sh
+++ b/kolla3/make-HELPER.sh
@@ -1,0 +1,60 @@
+
+
+make_cloud_init_seed(){
+  # creates $NAME-cloud_init_seed.iso
+  
+  local NAME=$1
+  local HOST_IP=$2
+
+  IID=$(uuidgen)
+
+  cat >$NAME-meta-data <<EOF
+local-hostname: $NAME
+instance-id: $IID
+EOF
+
+  cat >$NAME-network_config_static.cfg <<EOF
+version: 2
+ethernets:
+  ens3:
+    dhcp4: false
+    # default libvirt network
+    addresses: [ 192.168.122.$HOST_IP/24 ]
+    gateway4: 192.168.122.1
+    nameservers:
+      addresses: [ 192.168.122.1 ]
+      search: []
+  ens4:
+    addresses: []
+  ens5:
+    addresses: [ 192.168.200.$HOST_IP/24 ]
+EOF
+
+
+  cat >$NAME-cloud_init.cfg <<EOF
+#cloud-config
+users:
+  - name: $USER
+    ssh-authorized-keys:
+      - $PUB_KEY
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    groups: sudo
+    shell: /bin/bash
+chpasswd:
+  list: |
+     $USER:pw
+  expire: False
+
+runcmd:
+  - echo "AllowUsers $USER" >> /etc/ssh/sshd_config
+  - restart ssh
+
+package_update: true
+packages:
+  - qemu-guest-agent
+EOF
+
+  cloud-localds -v --network-config=$NAME-network_config_static.cfg $NAME-cloud_init_seed.iso $NAME-cloud_init.cfg $NAME-meta-data
+  rm $NAME-network_config_static.cfg $NAME-cloud_init.cfg $NAME-meta-data
+}
+

--- a/kolla3/make-computes.sh
+++ b/kolla3/make-computes.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+set -e
+
+source $(dirname "$0")/make-CONSTANTS.sh
+source $(dirname "$0")/make-HELPER.sh
+
 if [[ $# != 1 ]]
 then
     echo need machine number and nothing else
@@ -6,10 +12,18 @@ else
     NUM=$1
 fi
 
-[ ! -f c$NUM.qcow2 ] && sudo qemu-img create -f qcow2 -b ubuntu-base.qcow2 -F qcow2 c$NUM.qcow2  
+pushd $IMAGES_AND_ISOS
+
+make_cloud_init_seed c$NUM $((200 + $NUM))
+[ ! -f c$NUM.qcow2 ] && sudo qemu-img create -f qcow2 -o backing_file=$BASE_IMAGE -F qcow2 ./c$NUM.qcow2 50G
 
 sudo virt-install --noautoconsole --cpu host --name c$NUM --ram $((12*1024)) --vcpus 3 \
-                  --graphics vnc,listen=0.0.0.0,port=593$1  \
-                  --network network=default --network network=provider --network network=lbmgmt   \
+                  --graphics vnc,listen=0.0.0.0,port=591$NUM  \
+                  --virt-type kvm --os-type Linux --os-variant $OS_VARIANT \
+                  --network network=default --network network=provider --network network=lbmgmt \
                   --import                                     \
-                  --disk c$NUM.qcow2,bus=scsi                   
+                  --disk ./c$NUM.qcow2,bus=scsi                   \
+                  --disk path=./c$NUM-cloud_init_seed.iso,device=cdrom \
+
+popd
+

--- a/kolla3/make-elastic.sh
+++ b/kolla3/make-elastic.sh
@@ -1,4 +1,29 @@
-[[ ! -f elastic.qcow2 ]] && sudo qemu-img create -f qcow2 -b ubuntu-base.qcow2 -F qcow2 elastic.qcow2
+#!/bin/bash
+set -e
+
+source $(dirname "$0")/make-CONSTANTS.sh
+source $(dirname "$0")/make-HELPER.sh
+
+if [[ $# != 1 ]]
+then
+    echo need machine number and nothing else
+    exit 1
+else
+    NUM=$1
+fi
+
+pushd $IMAGES_AND_ISOS
+
+make_cloud_init_seed elastic $((200 + $NUM))
+[ ! -f elastic.qcow2 ] && sudo qemu-img create -f qcow2 -o backing_file=$BASE_IMAGE -F qcow2 ./elastic.qcow2 50G
+
 sudo virt-install --noautoconsole --cpu host --name elastic --ram 8192 --vcpus 2 \
-	          --graphics vnc,listen=0.0.0.0,port=5919 --network network=default \
-		  --import --disk elastic.qcow2,bus=scsi
+                  --graphics vnc,listen=0.0.0.0,port=591$NUM  \
+                  --virt-type kvm --os-type Linux --os-variant $OS_VARIANT \
+                  --network network=default --network network=provider --network network=lbmgmt \
+                  --import                                     \
+                  --disk ./elastic.qcow2,bus=scsi                   \
+                  --disk path=./elastic-cloud_init_seed.iso,device=cdrom \
+
+popd
+

--- a/kolla3/make-net.sh
+++ b/kolla3/make-net.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+virsh net-define $(dirname "$0")/lbmgmt.xml
+virsh net-autostart lbmgmt
+virsh net-start lbmgmt
+
+virsh net-define $(dirname "$0")/provider.xml
+virsh net-autostart provider
+virsh net-start provider

--- a/kolla3/make-prepare.sh
+++ b/kolla3/make-prepare.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+source $(dirname "$0")/make-CONSTANTS.sh
+
+mkdir -p $IMAGES_AND_ISOS
+
+[ ! -f $BASE_IMAGE ] && wget https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img -O $BASE_IMAGE
+sha256sum $BASE_IMAGE
+qemu-img info $BASE_IMAGE
+

--- a/kolla3/make-servers.sh
+++ b/kolla3/make-servers.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+set -e
+
+source $(dirname "$0")/make-CONSTANTS.sh
+source $(dirname "$0")/make-HELPER.sh
+
 if [[ $# != 1 ]]
 then
     echo need machine number and nothing else
@@ -6,14 +12,22 @@ else
     NUM=$1
 fi
 
-[ ! -f k$NUM.qcow2 ] && sudo qemu-img create -f qcow2 -b ubuntu-base.qcow2 -F qcow2 k$NUM.qcow2  
+pushd $IMAGES_AND_ISOS
+
+make_cloud_init_seed k$NUM $((200 + $NUM))
+[ ! -f k$NUM.qcow2 ] && sudo qemu-img create -f qcow2 -o backing_file=$BASE_IMAGE -F qcow2 ./k$NUM.qcow2 50G
 
 sudo virt-install --noautoconsole --cpu host --name k$NUM --ram $((12*1024)) --vcpus 3 \
-                  --graphics vnc,listen=0.0.0.0,port=591$1  \
+                  --graphics vnc,listen=0.0.0.0,port=591$NUM  \
+                  --virt-type kvm --os-type Linux --os-variant $OS_VARIANT \
                   --network network=default --network network=provider --network network=lbmgmt \
                   --import                                     \
-                  --disk k$NUM.qcow2,bus=scsi                   \
-                  --disk k$NUM-swift1.qcow2,size=50,bus=scsi    \
-                  --disk k$NUM-swift2.qcow2,size=50,bus=scsi    \
-                  --disk k$NUM-swift3.qcow2,size=50,bus=scsi    \
-                  --disk k$NUM-cinder.qcow2,size=50,bus=scsi    
+                  --disk ./k$NUM.qcow2,bus=scsi                   \
+                  --disk ./k$NUM-swift1.qcow2,size=50,bus=scsi    \
+                  --disk ./k$NUM-swift2.qcow2,size=50,bus=scsi    \
+                  --disk ./k$NUM-swift3.qcow2,size=50,bus=scsi    \
+                  --disk ./k$NUM-cinder.qcow2,size=50,bus=scsi    \
+                  --disk path=./k$NUM-cloud_init_seed.iso,device=cdrom \
+
+popd
+

--- a/kolla3/prepare.sh
+++ b/kolla3/prepare.sh
@@ -1,42 +1,50 @@
-
+#!/bin/bash
+set -e
 #################################################################
-       Installs software on a virgin Ubuntu 20
-       Probably needs to run on the deployer only
+#       Installs software on a virgin Ubuntu 20
+#       Probably needs to run on the deployer only
 #################################################################
 
+sudo apt update
 sudo apt install python3-dev libffi-dev gcc libssl-dev -y
+sudo apt install qemu-utils virtinst virt-manager git cloud-image-utils docker.io curl -y
+sudo usermod -a -G libvirt $USER
+sudo usermod -a -G kvm $USER
+
+[ ! -f ~/.ssh/id_ed25519 ] && ssh-keygen -f ~/.ssh/id_ed25519 -t ed25519 -C "$USER@labserver" -N ""
 
 # make venv
 #
 sudo apt install python3-venv -y
 python3 -m venv ~/venv
-source ~/venv/bin/activate
-echo source ~/venv/bin/activate >> .bashrc
 
-# update pip and install the correct version of Ansible
+source ~/venv/bin/activate
+echo source ~/venv/bin/activate >> ~/.bashrc
+
+# update pip and install requirements
 #
 pip install -U pip
-pip install 'ansible<2.10'
+pip install -r $(dirname "$0")/requirements.txt
 
 # install and configure Kolla-Ansible
-#
-pip install kolla-ansible
 sudo mkdir -p /etc/kolla
-sudo chown stack:stack /etc/kolla
+sudo chown $USER:$USER /etc/kolla
 cp -r ~/venv/share/kolla-ansible/etc_examples/kolla/* /etc/kolla
-cp ~/venv/share/kolla-ansible/ansible/inventory/* .
+cp $(dirname "$0")/globals.yml /etc/kolla
+ln -s $(dirname "$0")/multi-compute ./multi-compute
 
 # Ansible config
 #
-sudo mkdir /etc/ansible
+sudo mkdir -p /etc/ansible
 cat <<EOF | sudo tee /etc/ansible/ansible.cfg
 [defaults]
 host_key_checking=False
 pipelining=True
 forks=100
-log_path=/home/stack/ansible.log
+log_path=/home/$USER/ansible.log
 EOF
 
 # create passwords in /etc/kolla/passwords.yml
 #
-kolla-genpwd
+[ ! -f /etc/kolla/passwords.yml ] && kolla-genpwd
+

--- a/kolla3/requirements.txt
+++ b/kolla3/requirements.txt
@@ -1,0 +1,8 @@
+ansible<2.10
+kolla-ansible
+python-openstackclient
+python-octaviaclient
+python-neutronclient
+osc-placement
+diskimage-builder
+


### PR DESCRIPTION
This merge request removes the need for the manual ubuntu installation and the manual network setup on the VMs.

```
./openstack-bootcamp/kolla3/prepare.sh
#logout or reboot to reload user groups

./openstack-bootcamp/kolla3/make-prepare.sh
./openstack-bootcamp/kolla3/make-net.sh
./openstack-bootcamp/kolla3/make-servers.sh 1
./openstack-bootcamp/kolla3/make-servers.sh 2
./openstack-bootcamp/kolla3/make-servers.sh 3
./openstack-bootcamp/kolla3/make-computes.sh 4
./openstack-bootcamp/kolla3/make-computes.sh 5
./openstack-bootcamp/kolla3/make-elastic.sh 9
```
should be sufficient to prepare a fresh ubuntu installtion for the kolla-ansible run.

In my case I had to replace all occurrences of ens3,ens4,ens5 with enp1s0, enp2s0, enp3s0 (in globals.yml and make-HELPER.sh), though that was not the case with the original host.